### PR TITLE
[~BUGFIX] Fixed layout definition causing "Invalid block type" exception

### DIFF
--- a/src/app/design/frontend/base/default/layout/factfinder.xml
+++ b/src/app/design/frontend/base/default/layout/factfinder.xml
@@ -55,11 +55,9 @@
             <block type="factfinder/campaign_product_advisory" before="product.info" template="factfinder/campaign/product/advisory.phtml" />
             <block type="factfinder/campaign_product_feedback" before="product.info" template="factfinder/campaign/product/feedback.phtml" />
     	</reference>
-    	<reference>
-    	    <block name="product.info.upsell">
-    	    	<action method="setItemLimit"><type>upsell</type><limit>20</limit></action>
-    	    </block>
-		</reference>
+        <reference name="product.info.upsell">
+            <action method="setItemLimit"><type>upsell</type><limit>20</limit></action>
+        </reference>
     </catalog_product_view>
 
     <checkout_cart_index>


### PR DESCRIPTION
There was probably a typo in the layout XML: reference tag had no name attribute and the nested block tag had no type definition. This was causing an exception on every catalog_product_view page.
