### PR TITLE
Fixed minor layout bug in factfinder.xml

### DIFF
--- a/src/app/design/frontend/base/default/layout/factfinder.xml
+++ b/src/app/design/frontend/base/default/layout/factfinder.xml
@@ -55,11 +55,9 @@
             <block type="factfinder/campaign_product_advisory" before="product.info" template="factfinder/campaign/product/advisory.phtml" />
             <block type="factfinder/campaign_product_feedback" before="product.info" template="factfinder/campaign/product/feedback.phtml" />
     	</reference>
-    	<reference>
-    	    <block name="product.info.upsell">
+    	<reference name="product.info.upsell">
     	    	<action method="setItemLimit"><type>upsell</type><limit>20</limit></action>
-    	    </block>
-		</reference>
+   	</reference>
     </catalog_product_view>
 
     <checkout_cart_index>


### PR DESCRIPTION
The reference for upsells was broken - caused an uncritical exception, at least on Magento CE 1.7.0.2. Fixed it to avoid that exception (I like my logs clean).
