### PR TITLE
[BUG] Product export does not contain category paths

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/Model/Export/Product.php
+++ b/src/app/code/community/Flagbit/FactFinder/Model/Export/Product.php
@@ -456,7 +456,7 @@ class Flagbit_FactFinder_Model_Export_Product extends Mage_CatalogSearch_Model_M
                     )
                 )
                 ->where('main.store_id = ?', $storeId)
-                ->where('e.path LIKE \'1/' . Mage::app()->getStore()->getRootCategoryId() .'/%\'')
+                ->where('e.path LIKE \'1/' . Mage::app()->getStore($storeId)->getRootCategoryId() .'/%\'')
                 ->group('main.product_id');
             
             $this->_productsToCategoryPath = $this->_getReadAdapter()->fetchPairs($select);


### PR DESCRIPTION
The product export does not contain category paths. 
Fixed in Export/Product where the filter for the root category is using the default store instead of the storeId given as method parameter
