### PR TITLE
#54: Prevent fatal errors in 'factfinder/search_collection' resource mod...

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/Model/Mysql4/Search/Collection.php
+++ b/src/app/code/community/Flagbit/FactFinder/Model/Mysql4/Search/Collection.php
@@ -53,11 +53,11 @@ class Flagbit_FactFinder_Model_Mysql4_Search_Collection
     	$productIds = $this->_getSearchHandler()->getSearchResult();
 
         Mage::getSingleton('core/session')->setFactFinderRefKey(null);
-        if($refKey = Mage::getSingleton('factfinder/facade')->getSearchResult()->getRefKey())
-        {
-            Mage::getSingleton('core/session')->setFactFinderRefKey($refKey);
+        $searchResult = Mage::getSingleton('factfinder/facade')->getSearchResult();
+        if ($searchResult && $searchResult->getRefKey()) {
+            Mage::getSingleton('core/session')->setFactFinderRefKey($searchResult->getRefKey());
         }
-			
+
 		if (!empty($productIds)) {
 			$idFieldName = Mage::helper('factfinder/search')->getIdFieldName();
 


### PR DESCRIPTION
...el

For several possible reasons - server not reachable, return value not parsable, etc - the facade method _getFactFinderObject might return NULL instead of the requested object. Therefore, it is not correct to assume that the object will always be instantiated correctly, no matter what. Check if the object really exists before calling a method on it.
