### PR TITLE
DataNotLoadedException thrown by triggerImport in ImportAdapter

### DIFF
--- a/src/lib/FACTFinder/Xml65/ImportAdapter.php
+++ b/src/lib/FACTFinder/Xml65/ImportAdapter.php
@@ -33,6 +33,8 @@ class FACTFinder_Xml65_ImportAdapter extends FACTFinder_Default_ImportAdapter
      */
     protected function getData()
     {
+        FACTFinder_Http_ParallelDataProvider::loadAllData();
+
         libxml_use_internal_errors(true);
         return new SimpleXMLElement(parent::getData()); //throws exception on error
     }


### PR DESCRIPTION
A DataNotLoadedException with message

```
Implementation Error: the data is not up to date. Please use 'FACTFinder_Http_ParallelDataProvider::loadAllData' before trying to get data!
```

is thrown then i trigger the Server via import adapter to import the data or suggest.

The problem is that params are set in

``` php
FACTFinder_Xml65_ImportAdapter::triggerImport()
```

without a

``` php
FACTFinder_Http_ParallelDataProvider::loadAllData();
```

call after it.
