### PR TITLE
add order to requestParams on category view to use default sorting

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/Model/Handler/Search.php
+++ b/src/app/code/community/Flagbit/FactFinder/Model/Handler/Search.php
@@ -92,6 +92,10 @@ class Flagbit_FactFinder_Model_Handler_Search
                 $requestParams['Category'] = $this->_getCurrentFactFinderCategoryPath();
             }
 
+            if(!isset($requestParams['order'])) {
+                $requestParams['order'] = $helper->getCurrentOrder();
+            }
+
 
             $params['navigation'] = 'true';
 


### PR DESCRIPTION
If you are on a category view without using a sorting option, than FACTFinder will return the products sorted by best matching instead of using the configured default sort by field in the shop.