### PR TITLE
use SKU from canfigurable instead of simple product

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/Model/Observer.php
+++ b/src/app/code/community/Flagbit/FactFinder/Model/Observer.php
@@ -142,9 +142,11 @@ class Flagbit_FactFinder_Model_Observer
                 continue;
             }
 
+            $product = $item->getProduct();
+            /* @var $product Mage_Catalog_Model_Product */
             try {
                 Mage::getModel('factfinder/scic_queue')
-                    ->setProductId($item->getData($idFieldName))
+                    ->setProductId($product->getData($idFieldName))
                     ->setSid(md5(Mage::getSingleton('core/session')->getSessionId()))
                     ->setUserid($customerId)
                     ->setPrice($item->getPrice())


### PR DESCRIPTION
If you have configurable products, in the order is saved the sku of the simple product in parent and child.
So you have to load first the product from the item to get the right sku.