### PR TITLE
use product_list block to get the toolbar block on category view

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/Helper/Search.php
+++ b/src/app/code/community/Flagbit/FactFinder/Helper/Search.php
@@ -295,7 +295,12 @@ class Flagbit_FactFinder_Helper_Search extends Mage_Core_Helper_Abstract {
         if($mainBlock instanceof Mage_CatalogSearch_Block_Result){
             $toolbarBlock = $mainBlock->getListBlock()->getToolbarBlock();
         }else{
-            $toolbarBlock = Mage::app()->getLayout()->createBlock('catalog/product_list_toolbar');
+            $mainBlock = Mage::app()->getLayout()->getBlock('product_list');
+            if($mainBlock instanceof Mage_Catalog_Block_Product_List) {
+                $toolbarBlock = $mainBlock->getToolbarBlock();
+            } else {
+                $toolbarBlock = Mage::app()->getLayout()->createBlock('catalog/product_list_toolbar');
+            }
         }
 
         return $toolbarBlock;


### PR DESCRIPTION
On category view is no search.result block available, but you can get the toolbar block from the product_list block, so it don't have to be created so many times. On category view the toolbar is created every time you ask for the toolbar block.