### PR TITLE
Correct Content-Type Header in Flagbit_FactFinder_ProxyController::suggestAction

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/controllers/ProxyController.php
+++ b/src/app/code/community/Flagbit/FactFinder/controllers/ProxyController.php
@@ -44,7 +44,7 @@ class Flagbit_FactFinder_ProxyController extends Mage_Core_Controller_Front_Acti
      */	
 	public function suggestAction()
 	{
-		$this->getResponse()->setHeader("Content-Type:", "text/javascript;charset=utf-8", true);
+		$this->getResponse()->setHeader("Content-Type", "text/javascript;charset=utf-8", true);
 		$this->getResponse()->setBody(
 			Mage::getModel('factfinder/processor')->handleInAppRequest($this->getFullActionName())
 		);


### PR DESCRIPTION
Hi,

the setHeader Function expects the Header Name without ":".