### PR TITLE
replace connect20/flagbit_factfinder ~3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "license": "GPL3",
     "type": "magento-module",
     "description": "Flagbit FACTFinder",
+    "replace": {
+        "connect20/flagbit_factfinder": "~3.3"
+    },
     "require": {
         "magento-hackathon/magento-composer-installer": "*"
     },


### PR DESCRIPTION
marks the original package to replace the connect20 packaged one from firegento. versions on firegento currently are 3.3.12, 3.3.11, 3.3.10 and 3.3.9. versions on https://github.com/Flagbit/Magento-FACTFinder/ currently are 3.3.0 up to 3.6.0-beta. so this should be able to satisfy all connect20/flagbit_factfinder requirements to the latest version of flagbit/factfinder.

Reference: http://packages.firegento.com/#!/flagbit_factfinder

