### PR TITLE
fixed html-encoding

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/Block/Adminhtml/Form/Field/Attribute.php
+++ b/src/app/code/community/Flagbit/FactFinder/Block/Adminhtml/Form/Field/Attribute.php
@@ -46,7 +46,8 @@ class Flagbit_FactFinder_Block_Adminhtml_Form_Field_Attribute extends Mage_Core_
     {
         if (!$this->getOptions()) {
             foreach ($this->_getAttributes() as $id => $label) {
-                $this->addOption($id, addslashes($label));
+                $htmlLabel = htmlspecialchars($label, ENT_QUOTES);
+                $this->addOption($id, $htmlLabel);
             }
         }
         return parent::_toHtml();


### PR DESCRIPTION
option tag text-data (labels) for a HTML select tag were not properly HTML encoded via addslashes().

`addslashes()` is not only insufficient to encode string-data as HTML, it can also trigger javascript errors on the frontend as `\Mage_Core_Helper_Abstract::jsQuoteEscape()` can't properly deal with double slash sequences ("`\\`"). That method is applied later on on the overall HTML output for javascript based templating.

the issue has been fixed by using htmlspecialchars() encoding single- and double-quotes with the default encoding (PHP < 5.4: ISO-8859-1; PHP 5.4, 5.5: UTF-8; PHP 5.6+: `ini_get("default_charset")`).