### PR TITLE
fix pressing enter in search box

### DIFF
--- a/src/js/factfinder/suggest.js
+++ b/src/js/factfinder/suggest.js
@@ -218,6 +218,8 @@ var FactFinderSuggest = Class.create(Varien.searchForm, {
             this.field.value = element.title;
 
             this.form.submit();
+        } else {
+            this.form.submit();
         }
     }
 });


### PR DESCRIPTION
when the user inputs text into the search box, the suggest mechanism
starts to lookup suggestions that are then displayed in a dropdown. when
that dropdown is (going to be) shown, the focus is still seen in the
text-input but pressing enter does not submit the search form any longer.
the user then needs to press enter a second time.

this behavior has been fixed by this patch providing a submit on first
enter within the text-input element already.

----

fixes #39 for the part of:

> Also using "Enter" if no suggest is selected should simply start a
> search with the inserted query.

@rudibatt on Sep 23, 2013 <http://git.io/vYd3g>