### PR TITLE
Fix export for multi store setups

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
@@ -280,10 +280,7 @@ class FACTFinder_Core_Model_Export_Product extends Mage_CatalogSearch_Model_Reso
      */
     public function doExport($storeId = null)
     {
-        // reset internal state
-        $this->_lines = array();
-        $this->_categoryNames = null;
-        $this->_productsToCategoryPath = null;
+        $this->_resetInternalState();
 
         $idFieldName = Mage::helper('factfinder/search')->getIdFieldName();
 
@@ -396,6 +393,16 @@ class FACTFinder_Core_Model_Export_Product extends Mage_CatalogSearch_Model_Reso
         return $this->_lines;
     }
 
+    /**
+     * Resets the internal state of this export.
+     */
+    protected function _resetInternalState()
+    {
+        $this->_lines = array();
+        $this->_categoryNames = null;
+        $this->_productsToCategoryPath = null;
+        $this->_exportAttributes = null;
+    }
 
     /**
      * Get attributes by type

--- a/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
@@ -339,11 +339,17 @@ class FACTFinder_Core_Model_Export_Product extends Mage_CatalogSearch_Model_Reso
                     continue;
                 }
 
+				$categoryPath = $this->_getCategoryPath($productData['entity_id'], $storeId);
+                
+				if ($categoryPath == '') {
+                    continue;
+                }
+
                 $productIndex = array(
                     $productData['entity_id'],
                     $productData[$idFieldName],
                     $productData['sku'],
-                    $this->_getCategoryPath($productData['entity_id'], $storeId),
+                    $categoryPath,
                     $this->_formatAttributes('filterable', $productAttr, $storeId),
                     $this->_formatAttributes('searchable', $productAttr, $storeId),
                     $this->_formatAttributes('numerical', $productAttr, $storeId),

--- a/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
@@ -282,8 +282,8 @@ class FACTFinder_Core_Model_Export_Product extends Mage_CatalogSearch_Model_Reso
     {
         // reset internal state
         $this->_lines = array();
-		$this->_categoryNames = null;
-		$this->_productsToCategoryPath = null;
+        $this->_categoryNames = null;
+        $this->_productsToCategoryPath = null;
 
         $idFieldName = Mage::helper('factfinder/search')->getIdFieldName();
 
@@ -339,9 +339,9 @@ class FACTFinder_Core_Model_Export_Product extends Mage_CatalogSearch_Model_Reso
                     continue;
                 }
 
-				$categoryPath = $this->_getCategoryPath($productData['entity_id'], $storeId);
-                
-				if ($categoryPath == '') {
+                $categoryPath = $this->_getCategoryPath($productData['entity_id'], $storeId);
+
+                if ($categoryPath == '') {
                     continue;
                 }
 

--- a/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Export/Product.php
@@ -280,8 +280,10 @@ class FACTFinder_Core_Model_Export_Product extends Mage_CatalogSearch_Model_Reso
      */
     public function doExport($storeId = null)
     {
-        // reset lines
+        // reset internal state
         $this->_lines = array();
+		$this->_categoryNames = null;
+		$this->_productsToCategoryPath = null;
 
         $idFieldName = Mage::helper('factfinder/search')->getIdFieldName();
 


### PR DESCRIPTION
Multi store setups may have totally different category trees. The export should be able to handle this. For example, a product may be in the category tree of store 1, but not in the tree of store 2. The export for store 2 should not contain this product.