### PR TITLE
Fix for limit urls when Magento is in a subdirectory

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/List/Toolbar.php
+++ b/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/List/Toolbar.php
@@ -110,7 +110,8 @@ class FACTFinder_Core_Block_Catalog_Product_List_Toolbar extends Mage_Catalog_Bl
 
         // using super global because magento doesn't return real uri
         // but its target like catalog/category/view
-        $currentRequest = explode('?', $_SERVER['REQUEST_URI']);
+        $urlWithoutBasePath = str_replace(parse_url($url, PHP_URL_PATH), '', $_SERVER['REQUEST_URI']);
+        $currentRequest = explode('?', $urlWithoutBasePath);
 
         if (count($currentRequest) > 1) {
             $params = array_pop($currentRequest);

--- a/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/List/Toolbar.php
+++ b/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/List/Toolbar.php
@@ -110,8 +110,7 @@ class FACTFinder_Core_Block_Catalog_Product_List_Toolbar extends Mage_Catalog_Bl
 
         // using super global because magento doesn't return real uri
         // but its target like catalog/category/view
-        $urlWithoutBasePath = str_replace(parse_url($url, PHP_URL_PATH), '', $_SERVER['REQUEST_URI']);
-        $currentRequest = explode('?', $urlWithoutBasePath);
+        $currentRequest = explode('?', $this->removeBasePathByBaseUrl($_SERVER['REQUEST_URI'], $url));
 
         if (count($currentRequest) > 1) {
             $params = array_pop($currentRequest);
@@ -126,6 +125,22 @@ class FACTFinder_Core_Block_Catalog_Product_List_Toolbar extends Mage_Catalog_Bl
         }
     }
 
+    /**
+     * Uses a given base URL to remove subfolders from the current request path in case Magento is hosted in a
+     * subdirectory.
+     *
+     * @param string $fullPath The full request path.
+     * @param string $baseUrl The base URL of the Magento installation.
+     * @return string
+     */
+    private function removeBasePathByBaseUrl($fullPath, $baseUrl){
+        $basePath = parse_url($baseUrl, PHP_URL_PATH);
+        $pos = strpos($fullPath, $basePath);
+        if ($pos !== false) {
+            return substr_replace($fullPath, '', $pos, strlen($basePath));
+        }
+        return $fullPath;
+    }
 
     /**
      * Get sorting id


### PR DESCRIPTION
This fixes a bug with wrongly generated URLs of the toolbar product limit switcher when Magento is hosted in a subdirectory. The current implementation combines the Magento base URL with  $_SERVER['REQUEST_URI'] and therefore contains any subdirectories twice, i. e.: 

"https://example.com/shop" + "/shop/something"

With the fix any path appended to the base URL host will be removed from the start of the REQUEST_URI.