### PR TITLE
FIX: Disable custom class loading

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Model/Facade.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Facade.php
@@ -104,6 +104,8 @@ class FACTFinder_Core_Model_Facade
             $arg = Mage::helper('factfinder/debug');
         }
 
+        FF::disableCustomClasses();
+
         $dic = FF::getInstance('Util\Pimple');
 
         $dic['loggerClass'] = function ($c) use ($arg) {


### PR DESCRIPTION
The enabled custom class loading of the FACT-Finder PHP library produced error messages in the Magento system log.