### PR TITLE
Fix sort attributes which contains numbers in the attribute code

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/List/Toolbar.php
+++ b/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/List/Toolbar.php
@@ -228,7 +228,7 @@ class FACTFinder_Core_Block_Catalog_Product_List_Toolbar extends Mage_Catalog_Bl
             foreach ($sortings as $sorting) {
                 if ($sorting->isSelected()) {
                     $url = $sorting->getUrl();
-                    preg_match('/[\?|\&]{1}sort([a-z\_]*?)=/', $url, $matches);
+                    preg_match('/[\?|\&]{1}sort([a-z0-9\_]*?)=/', $url, $matches);
                     if (isset($matches[1])) {
                         return $matches[1];
                     }


### PR DESCRIPTION
Fixed an error if a product attribute has numbers in the attribute code and is used for sorting it is not marked as selected in the dropdown.