### PR TITLE
fix content-type also for 3.x branch

### DIFF
--- a/src/app/code/community/Flagbit/FactFinder/controllers/ProxyController.php
+++ b/src/app/code/community/Flagbit/FactFinder/controllers/ProxyController.php
@@ -44,7 +44,7 @@ class Flagbit_FactFinder_ProxyController extends Mage_Core_Controller_Front_Acti
      */	
 	public function suggestAction()
 	{
-		$this->getResponse()->setHeader("Content-Type:", "text/javascript;charset=utf-8", true);
+		$this->getResponse()->setHeader("Content-Type", "text/javascript;charset=utf-8", true);
 		$this->getResponse()->setBody(
 			Mage::getModel('factfinder/processor')->handleInAppRequest($this->getFullActionName())
 		);


### PR DESCRIPTION
#147 this fix is security related (XSS). Missing Content-Type enables reflected cross site scripting (tested in FF, doesn't happen in Chrome)

![pasted image at 2016_04_18 10_40](https://cloud.githubusercontent.com/assets/10241471/14598363/17fffed2-0552-11e6-9eb4-35bb740dd494.png)
