### PR TITLE
remove param "query"

### DIFF
--- a/src/app/code/community/FACTFinder/Suggest/Helper/Data.php
+++ b/src/app/code/community/FACTFinder/Suggest/Helper/Data.php
@@ -51,6 +51,16 @@ class FACTFinder_Suggest_Helper_Data extends Mage_Core_Helper_Abstract
 
         // avoid specifying the default port for http
         $url = preg_replace('/^(http:[^\:]+)\:80\//', "$1/", $url);
+		
+		// replace param "query"
+		$urlData = parse_url($url);
+		$queryString = '';
+		if (isset($urlData['query'])) {
+			parse_str($urlData['query'], $urlParams);
+			unset($urlParams['query']);
+			$queryString = http_build_query($urlParams);
+		}
+		$url = sprintf('%s://%s%s?%s', $urlData['scheme'], $urlData['host'], $urlData['path'], $queryString);
 
         return $url;
     }


### PR DESCRIPTION
On search results the "query" param exists in the base suggest url. If you change the search keyword the "query" param is in url and in options.

this.rq = new FactFinderAjax.Request(this.url, this.options);

And he doesn't use the new value from options.