### PR TITLE
Several improvements and fixes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
     <description>Integrates the FACT-Finder for improved product search functionality.</description>
     <license>Open Software License v3.0 (OSL-3.0)</license>
     <license_uri>http://opensource.org/licenses/OSL-3.0</license_uri>
-    <version>4.1.9</version>
+    <version>4.1.11</version>
     <stability>stable</stability>
     <notes>Completely refactored and now supporting FF v6.9-7.1</notes>
     <authors>

--- a/src/app/code/community/FACTFinder/Asn/etc/system.xml
+++ b/src/app/code/community/FACTFinder/Asn/etc/system.xml
@@ -21,7 +21,7 @@
                             <label>Replace Catalog Navigation</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>15</sort_order>
+                            <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Abstract.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Abstract.php
@@ -40,6 +40,7 @@ abstract class FACTFinder_Campaigns_Block_Abstract extends Mage_Core_Block_Templ
     {
         if (Mage::registry('current_category')
             && !Mage::helper('factfinder_campaigns')->isCatalogNavigationReplaced()
+            || Mage::registry('current_product')
         ) {
             return false;
         }

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Feedback/Page.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Feedback/Page.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * FACTFinder_Campaigns
+ *
+ * @category Mage
+ * @package FACTFinder_Campaigns
+ * @author tuegeb
+ * @copyright Copyright (c) 2016, tuegeb
+ * @license https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+
+/**
+ * Class FACTFinder_Campaigns_Block_Feedback_Page
+ *
+ * @category Mage
+ * @package FACTFinder_Campaigns
+ * @author tuegeb
+ * @copyright Copyright (c) 2016, tuegeb
+ * @license https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+class FACTFinder_Campaigns_Block_Feedback_Page extends FACTFinder_Campaigns_Block_Feedback_Abstract
+{
+
+    protected $_handlerModel = 'factfinder_campaigns/handler_page';
+
+    /**
+     * Check is the campign can be shown on landing page
+     *
+     * @return bool
+     */
+    protected function _canBeShown()
+    {
+        if (!Mage::registry('current_category')
+           || Mage::registry('current_category')->getDisplayMode() === Mage_Catalog_Model_Category::DM_PRODUCT
+           || !Mage::helper('factfinder_campaigns')->canShowLandingPageCampaigns())
+        {
+            return false;
+        }
+        return (bool) Mage::helper('factfinder')->isEnabled('campaigns');
+    }
+
+}

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Feedback/Product.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Feedback/Product.php
@@ -33,9 +33,12 @@ class FACTFinder_Campaigns_Block_Feedback_Product extends FACTFinder_Campaigns_B
      */
     protected function _canBeShown()
     {
-        $enabledOnProduct = Mage::helper('factfinder_campaigns')->canShowCampaignsOnProduct();
-
-        return parent::_canBeShown() && $enabledOnProduct;
+        if (!Mage::registry('current_product')
+            || !Mage::helper('factfinder_campaigns')->canShowCampaignsOnProduct())
+        {
+            return false;
+        }
+        return (bool) Mage::helper('factfinder')->isEnabled('campaigns');
     }
 
 

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Abstract.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Abstract.php
@@ -97,18 +97,6 @@ abstract class FACTFinder_Campaigns_Block_Pushed_Abstract extends Mage_Catalog_B
         return $this->__('Pushed products');
     }
 
-
-    /**
-     * Check if campaigns can be shown
-     *
-     * @return bool
-     */
-    protected function _canBeShown()
-    {
-        return (bool) Mage::helper('factfinder')->isEnabled('campaigns');
-    }
-
-
     /**
      * Render html
      * Return empty string if module isn't enabled
@@ -124,5 +112,21 @@ abstract class FACTFinder_Campaigns_Block_Pushed_Abstract extends Mage_Catalog_B
         return parent::_toHtml();
     }
 
+    /**
+     * Check if campaigns can be shown
+     *
+     * @return bool
+     */
+    protected function _canBeShown()
+    {
+        if (Mage::registry('current_category')
+            && !Mage::helper('factfinder_campaigns')->isCatalogNavigationReplaced()
+            || Mage::registry('current_product')
+        ) {
+            return false;
+        }
+
+        return (bool) Mage::helper('factfinder')->isEnabled('campaigns');
+    }
 
 }

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Page.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Page.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * FACTFinder_Campaigns
+ *
+ * @category Mage
+ * @package FACTFinder_Campaigns
+ * @author tuegeb
+ * @copyright Copyright (c) 2016, tuegeb
+ * @license https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+
+/**
+ * Class FACTFinder_Campaigns_Block_Pushed_Page
+ *
+ * @category Mage
+ * @package FACTFinder_Campaigns
+ * @author tuegeb
+ * @copyright Copyright (c) 2016, tuegeb
+ * @license https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+class FACTFinder_Campaigns_Block_Pushed_Page extends FACTFinder_Campaigns_Block_Pushed_Abstract
+{
+
+    protected $_handlerModel = 'factfinder_campaigns/handler_page';
+
+    /**
+     * Check is the campign can be shown on landing page
+     *
+     * @return bool
+     */
+    protected function _canBeShown()
+    {
+        if (!Mage::registry('current_category')
+           || Mage::registry('current_category')->getDisplayMode() === Mage_Catalog_Model_Category::DM_PRODUCT 
+           || !Mage::helper('factfinder_campaigns')->canShowLandingPageCampaigns())
+        {
+            return false;
+        }
+        return (bool) Mage::helper('factfinder')->isEnabled('campaigns');
+    }
+
+}

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Product.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Product.php
@@ -33,9 +33,12 @@ class FACTFinder_Campaigns_Block_Pushed_Product extends FACTFinder_Campaigns_Blo
      */
     protected function _canBeShown()
     {
-        $enabledOnProduct = Mage::helper('factfinder_campaigns')->canShowCampaignsOnProduct();
-
-        return parent::_canBeShown() && $enabledOnProduct;
+        if (!Mage::registry('current_product')
+            || !Mage::helper('factfinder_campaigns')->canShowCampaignsOnProduct())
+        {
+            return false;
+        }
+        return (bool) Mage::helper('factfinder')->isEnabled('campaigns');
     }
 
 

--- a/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Search.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Block/Pushed/Search.php
@@ -25,22 +25,4 @@ class FACTFinder_Campaigns_Block_Pushed_Search extends FACTFinder_Campaigns_Bloc
 
     protected $_handlerModel = 'factfinder_campaigns/handler_search';
 
-
-    /**
-     * Check if campaigns can be shown
-     *
-     * @return bool
-     */
-    protected function _canBeShown()
-    {
-        if (Mage::registry('current_category')
-            && !Mage::helper('factfinder_campaigns')->isCatalogNavigationReplaced()
-        ) {
-            return false;
-        }
-
-        return parent::_canBeShown();
-    }
-
-
 }

--- a/src/app/code/community/FACTFinder/Campaigns/Helper/Data.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Helper/Data.php
@@ -25,6 +25,7 @@ class FACTFinder_Campaigns_Helper_Data extends Mage_Core_Helper_Abstract
     const CATALOG_NAVIGATION_REPLACED_CONFIG_PATH = 'factfinder/modules/catalog_navigation';
     const CAMPAIGNS_IDENTIFIER_CONFIG_PATH = 'factfinder/config/campaigns_identifier';
     const ENABLE_CAMPAIGNS_ON_PROD_PAGE_CONFIG_PATH = 'factfinder/config/enable_campaigns_on_prod_page';
+    const ENABLE_LANDING_PAGE_CAMPAIGNS_CONFIG_PATH = 'factfinder/config/enable_landing_page_campaigns';
 
 
     /**
@@ -35,6 +36,16 @@ class FACTFinder_Campaigns_Helper_Data extends Mage_Core_Helper_Abstract
     public function canShowCampaignsOnProduct()
     {
         return (bool) Mage::app()->getStore()->getConfig(self::ENABLE_CAMPAIGNS_ON_PROD_PAGE_CONFIG_PATH);
+    }
+    
+    /**
+     * Check config if showing campaigns on product page is enabled
+     *
+     * @return bool
+     */
+    public function canShowLandingPageCampaigns()
+    {
+        return (bool) Mage::app()->getStore()->getConfig(self::ENABLE_LANDING_PAGE_CAMPAIGNS_CONFIG_PATH);
     }
 
 

--- a/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Abstract.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Abstract.php
@@ -35,6 +35,14 @@ abstract class FACTFinder_Campaigns_Model_Handler_Abstract extends FACTFinder_Co
      * @var array
      */
     protected $_productIds = array();
+    
+    /**
+     * Page IDs
+     *
+     * @var string
+     */
+    protected $_pageId = null;
+
 
     /**
      * Available campaigns
@@ -57,7 +65,7 @@ abstract class FACTFinder_Campaigns_Model_Handler_Abstract extends FACTFinder_Co
      *
      * @param array $productIds
      */
-    public function __construct($productIds)
+    public function __construct($productIds = null)
     {
         $this->_productIds = $productIds;
         parent::__construct();
@@ -90,7 +98,11 @@ abstract class FACTFinder_Campaigns_Model_Handler_Abstract extends FACTFinder_Co
         $params = array();
 
         $params['do'] = $this->_getDoParam();
-        $params['productNumber'] = $this->_getProductNumberParam();
+        if ($this instanceof FACTFinder_Campaigns_Model_Handler_Page) {
+            $params['pageId'] = $this->_getPageIdParam();
+        } else {
+            $params['productNumber'] = $this->_getProductNumberParam();
+        }
         $params['idsOnly'] = 'true';
         if(Mage::getStoreConfigFlag('factfinder/config/personalization')) {
             $params['sid'] = Mage::helper('factfinder_tracking')->getSessionId();
@@ -105,15 +117,6 @@ abstract class FACTFinder_Campaigns_Model_Handler_Abstract extends FACTFinder_Co
      * @return string
      */
     abstract protected function _getDoParam();
-
-
-    /**
-     * Get array of product ids
-     *
-     * @return array
-     */
-    abstract protected function _getProductNumberParam();
-
 
     /**
      * Get array of guestions from advisor campaign

--- a/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Cart.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Cart.php
@@ -61,9 +61,9 @@ class FACTFinder_Campaigns_Model_Handler_Cart extends FACTFinder_Campaigns_Model
     {
         if (!empty($this->_productIds)) {
             $this->_getFacade()->getProductCampaignAdapter()->makeShoppingCartCampaign();
+            return parent::getCampaigns();
         }
-
-        return parent::getCampaigns();
+        return array();
     }
 
 

--- a/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Page.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Page.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * FACTFinder_Campaigns
+ *
+ * @category Mage
+ * @package FACTFinder_Campaigns
+ * @author tuegeb
+ * @copyright Copyright (c) 2016, tuegeb
+ * @license https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+
+/**
+ * Class FACTFinder_Campaigns_Model_Handler_Page
+ *
+ * @category Mage
+ * @package FACTFinder_Campaigns
+ * @author tuegeb
+ * @copyright Copyright (c) 2016, tuegeb
+ * @license https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+class FACTFinder_Campaigns_Model_Handler_Page extends FACTFinder_Campaigns_Model_Handler_Abstract
+{
+    /**
+     * Class constructor
+     *
+     * @param string $pageId
+     */
+    public function __construct($pageId)
+    {
+        $this->_pageId = $pageId;
+        parent::__construct();
+    }
+
+    /**
+     * Get name of the method to be executed in the adapter
+     *
+     * @return string
+     */
+    protected function _getDoParam()
+    {
+        return 'getPageCampaigns';
+    }
+
+    /**
+     * Get page id
+     *
+     * @return string
+     */
+    protected function _getPageIdParam()
+    {
+        $this->_pageId = Mage::registry('current_category')->getId();
+        return $this->_pageId;
+    }
+
+    /**
+     * Get array of campaigns available
+     *
+     * @return array
+     */
+    public function getCampaigns()
+    {
+        if (isset($this->_pageId)) {
+            $this->_getFacade()->getProductCampaignAdapter()->makePageCampaign();
+            return parent::getCampaigns();
+        }
+        return array();
+    }
+
+}

--- a/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Product.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Model/Handler/Product.php
@@ -58,9 +58,9 @@ class FACTFinder_Campaigns_Model_Handler_Product extends FACTFinder_Campaigns_Mo
     {
         if (!empty($this->_productIds)) {
             $this->_getFacade()->getProductCampaignAdapter()->makeProductCampaign();
+            return parent::getCampaigns();
         }
-
-        return parent::getCampaigns();
+        return array();
     }
 
 

--- a/src/app/code/community/FACTFinder/Campaigns/etc/system.xml
+++ b/src/app/code/community/FACTFinder/Campaigns/etc/system.xml
@@ -17,24 +17,34 @@
             <groups>
                 <config>
                     <fields>
-                        <campaigns_identifier translate="label">
-                            <label>Campaigns Product Identifier</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>factfinder/system_config_source_identifier</source_model>
-                            <sort_order>11</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </campaigns_identifier>
                         <enable_campaigns_on_prod_page>
                             <label>Enable campaigns on product page</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>12</sort_order>
+                            <sort_order>25</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </enable_campaigns_on_prod_page>
+                        <enable_landing_page_campaigns>
+                            <label>Enable campaigns on landing page</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        <comment><![CDATA[Requires FACT-Finder >= 7.2.]]></comment>
+                        </enable_landing_page_campaigns>
+                        <campaigns_identifier translate="label">
+                            <label>Campaigns Product Identifier</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>factfinder/system_config_source_identifier</source_model>
+                            <sort_order>45</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </campaigns_identifier>
                     </fields>
                 </config>
             </groups>

--- a/src/app/code/community/FACTFinder/Core/etc/system.xml
+++ b/src/app/code/community/FACTFinder/Core/etc/system.xml
@@ -185,11 +185,20 @@
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
+                        <remove_tags translate="label">
+                            <label>Remove html entities and tags</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </remove_tags>
                         <products_without_categories translate="label">
                             <label>Export products without categories</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>10</sort_order>
+                            <sort_order>25</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -198,41 +207,25 @@
                             <label>Export out of stock products</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>15</sort_order>
+                            <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </out_of_stock_products>
-                        <remove_tags translate="label">
-                            <label>Remove html entities and tags</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>55</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </remove_tags>
                         <attributes translate="label">
                             <label>Attributes</label>
                             <frontend_model>factfinder/adminhtml_form_field_attributes</frontend_model>
                             <backend_model>factfinder/system_config_backend_attributes</backend_model>
-                            <sort_order>50</sort_order>
+                            <sort_order>35</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </attributes>
-                        <export_url translate="label">
-                            <frontend_model>factfinder/adminhtml_exportlink</frontend_model>
-                            <sort_order>60</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </export_url>
                         <trigger_data_import translate="label">
                             <label>Trigger Data Import</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>70</sort_order>
+                            <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -242,7 +235,7 @@
                             <label>Import Delay Enabled</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>75</sort_order>
+                            <sort_order>45</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -252,7 +245,7 @@
                             <label>Upload files to FTP host</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>100</sort_order>
+                            <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -261,7 +254,7 @@
                         <ftp_host translate="label">
                             <label>FTP Host</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>110</sort_order>
+                            <sort_order>55</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -270,7 +263,7 @@
                         <ftp_port translate="label">
                             <label>FTP Port</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>120</sort_order>
+                            <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -279,7 +272,7 @@
                         <ftp_user translate="label">
                             <label>FTP User</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>130</sort_order>
+                            <sort_order>65</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -288,7 +281,7 @@
                         <ftp_password translate="label">
                             <label>FTP Password</label>
                             <frontend_type>password</frontend_type>
-                            <sort_order>140</sort_order>
+                            <sort_order>70</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -297,7 +290,7 @@
                         <ftp_path translate="label">
                             <label>FTP Path</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>150</sort_order>
+                            <sort_order>75</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -307,13 +300,20 @@
                             <label>Use SSL</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>150</sort_order>
+                            <sort_order>80</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <depends><use_ftp>1</use_ftp></depends>
                             <comment><![CDATA[Yes for FTPS and No for FTP]]></comment>
                         </ftp_ssl>
+                        <export_url translate="label">
+                            <frontend_model>factfinder/adminhtml_exportlink</frontend_model>
+                            <sort_order>95</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </export_url>
                     </fields>
                 </export>
                 <config translate="label">
@@ -333,20 +333,11 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </personalization>
-                        <identifier translate="label">
-                            <label>Product Identifier</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>factfinder/system_config_source_identifier</source_model>
-                            <sort_order>10</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </identifier>
                         <redirectOnSingleResult>
                             <label>Redirect to product details page for single results</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>20</sort_order>
+                            <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -355,7 +346,7 @@
                             <label>Use sorting options</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>30</sort_order>
+                            <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -365,17 +356,26 @@
                             <label>Use results per page options</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>40</sort_order>
+                            <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[If enabled, it requires the configuration of default and alternative results per page options in the FACT-Finder backend.]]></comment>
                         </use_resultsPerPage>
+                        <identifier translate="label">
+                            <label>Product Identifier</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>factfinder/system_config_source_identifier</source_model>
+                            <sort_order>35</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </identifier>
                         <internal_ip translate="label">
                             <label>Internal IPs</label>
                             <comment>Enter your internal IP addresses. Multiple IP addresses should be separated by semicolons.</comment>
                             <frontend_type>text</frontend_type>
-                            <sort_order>90</sort_order>
+                            <sort_order>55</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -384,7 +384,7 @@
                             <label>Debug Log</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>100</sort_order>
+                            <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -435,24 +435,42 @@
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
-                        <asn translate="label">
-                            <label>Enable FACT-Finder After Search Navigation</label>
+                        <tracking>
+                            <label>Enable FACT-Finder Tracking</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>5</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </tracking>
+                        <suggest translate="label">
+                            <label>Enable FACT-Finder Suggest</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </asn>
-                        <suggest translate="label">
-                            <label>Enable FACT-Finder Suggest</label>
+                        </suggest>
+                        <asn translate="label">
+                            <label>Enable FACT-Finder After Search Navigation</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>20</sort_order>
+                            <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </suggest>
+                        </asn>
+                        <campaigns>
+                            <label>Enable FACT-Finder Campaigns</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>25</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </campaigns>
                         <recommendation translate="label">
                             <label>Enable FACT-Finder Recommendation</label>
                             <frontend_type>select</frontend_type>
@@ -466,29 +484,11 @@
                             <label>Enable FACT-Finder Tag Cloud</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>40</sort_order>
+                            <sort_order>35</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </tagcloud>
-                        <tracking>
-                            <label>Enable FACT-Finder Tracking</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>50</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </tracking>
-                        <campaigns>
-                            <label>Enable FACT-Finder Campaigns</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>60</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </campaigns>
                     </fields>
                 </modules>
             </groups>

--- a/src/app/code/community/FACTFinder/Suggest/etc/system.xml
+++ b/src/app/code/community/FACTFinder/Suggest/etc/system.xml
@@ -35,7 +35,7 @@
                             <label>Export Images and Deeplinks</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>10</sort_order>
+                            <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -44,7 +44,7 @@
                             <label>Size of Suggest images</label>
                             <comment>Please enter the desired edge length of the Suggest images in pixels. If you do not want them to be resized, enter 0.</comment>
                             <frontend_type>text</frontend_type>
-                            <sort_order>15</sort_order>
+                            <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -53,7 +53,7 @@
                             <label>Type of Suggest images</label>
                             <frontend_type>select</frontend_type>
                             <source_model>factfinder_suggest/system_config_source_imagetype</source_model>
-                            <sort_order>16</sort_order>
+                            <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -62,7 +62,7 @@
                             <label>Trigger Suggest Import</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>80</sort_order>
+                            <sort_order>85</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -76,7 +76,7 @@
                             <label>Use Proxy for Suggest</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>10</sort_order>
+                            <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/src/app/code/community/FACTFinder/Tracking/Block/Recommendation.php
+++ b/src/app/code/community/FACTFinder/Tracking/Block/Recommendation.php
@@ -35,8 +35,8 @@ class FACTFinder_Tracking_Block_Recommendation extends FACTFinder_Tracking_Block
     {
         $collection = Mage::registry('recommendation_collection');
 
-        if (!$collection instanceof FACTFinder_Core_Model_Resource_Search_Collection) {
-            $collection = Mage::getResourceModel('factfinder/search_collection');
+        if (empty($collection)) {
+            $collection = array();
         }
 
         return $collection;

--- a/src/app/code/community/FACTFinder/Tracking/etc/system.xml
+++ b/src/app/code/community/FACTFinder/Tracking/etc/system.xml
@@ -22,7 +22,7 @@
                             <label>Track product-clicks</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>20</sort_order>
+                            <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -31,7 +31,7 @@
                             <label>Track "Add to cart" events</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>30</sort_order>
+                            <sort_order>105</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -40,7 +40,7 @@
                             <label>Track checkout</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>40</sort_order>
+                            <sort_order>110</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -53,7 +53,7 @@
                             <label>Tracking Product Identifier</label>
                             <frontend_type>select</frontend_type>
                             <source_model>factfinder/system_config_source_identifier</source_model>
-                            <sort_order>12</sort_order>
+                            <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/src/app/design/frontend/base/default/layout/factfinder/campaigns.xml
+++ b/src/app/design/frontend/base/default/layout/factfinder/campaigns.xml
@@ -67,6 +67,16 @@
 
     <catalog_category_view>
         <reference name="content">
+             <!-- landing page pushed products -->
+            <block type="factfinder_campaigns/pushed_page" name="page.pushed" before="category.products">
+                <action method="setMaxColNum"><num>3</num></action>
+                <block type="factfinder_campaigns/feedback_page" before="page.pushed" name="ff.feedback.above.pushed" as="feedback_above">
+                    <action method="setLabel"><label>above pushed product</label></action>
+                </block>
+                <block type="factfinder_campaigns/feedback_page" after="page.pushed" name="ff.feedback.below.pushed" as="feedback_below">
+                    <action method="setLabel"><label>below pushed product</label></action>
+                </block>
+            </block>
             <block type="factfinder_campaigns/advisory_search" name="ff.search.advisory" before="-" template="factfinder/campaigns/advisory.phtml" />
             <!-- pushed products -->
             <block type="factfinder_campaigns/pushed_search" name="search.pushed" after="ff.search.advisory">

--- a/src/js/factfinder/tracking.js
+++ b/src/js/factfinder/tracking.js
@@ -40,14 +40,14 @@ var FactfinderTracking = Class.create({
 
             if(element.readAttribute('href')) {
                 var match = this.regex.exec(element.readAttribute('href'));
-                if(match && match[1]) {
+                if(match && match[1] && !this.irrelevantLink(element.readAttribute('class'))) {
                     return this.prepareElement(element, match[1], 'click');
                 }
             }
 
             if(element.readAttribute('onclick')) {
                 var match = this.regex.exec(element.readAttribute('onclick'));
-                if(match && match[1]) {
+                if(match && match[1] && !this.irrelevantLink(element.readAttribute('class'))) {
                     return this.prepareElement(element, match[1], 'click');
                 }
             }
@@ -69,6 +69,13 @@ var FactfinderTracking = Class.create({
             method: 'post',
             parameters: data
         });
+        return false;
+    },
+    
+    irrelevantLink: function (classAttribute) {
+        if (classAttribute != null && (classAttribute.indexOf('link-wishlist') != -1 || classAttribute.indexOf('link-compare') != -1)) {
+            return true;
+        }
         return false;
     }
 });


### PR DESCRIPTION
- Solves: 
 - click tracking caused by compare and wishlist links
 - empty search request which is caused by recommendation click tracking implementation
 - empty campaign requests on cart and detail page
- Adds:
 - page campaigns for categories with display mode != "products only"
- Improves:
 - configuration options order
- Tested with Magento editions/versions: 1.9.2
- Tested with PHP versions: 5.6