### PR TITLE
Different config names for disabled_validation

### DIFF
--- a/src/app/code/community/FACTFinder/Core/etc/system.xml
+++ b/src/app/code/community/FACTFinder/Core/etc/system.xml
@@ -314,7 +314,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </export_url>
-                        <disable_validation translate="label comment">
+                        <disabled_validation translate="label comment">
                             <label>Disable export feed validation</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
@@ -323,7 +323,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[This can be used in case of unpredicted problems with export data validation]]></comment>
-                        </disable_validation>
+                        </disabled_validation>
                     </fields>
                 </export>
                 <config translate="label">


### PR DESCRIPTION
- Tested with Magento editions/versions: 1.14.3.1
- Tested with PHP versions: 7.0.3

### Please note that the source and target branch must be "develop" (details: https://github.com/Flagbit/Magento-FACTFinder/wiki/Guide-for-Contributors).
app/code/community/FACTFinder/Core/etc/system.xml uses "disable_validation" (without the e) and
app/code/community/FACTFinder/Core/Helper/Export.php uses "disabled_validation" (with the e)