### PR TITLE
[BUG] fixed multiselect values in product export

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Model/Export/Type/Product.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Export/Type/Product.php
@@ -639,7 +639,9 @@ class FACTFinder_Core_Model_Export_Type_Product extends Mage_Core_Model_Abstract
             $attribute->setStoreId($storeId);
             $value = $attribute->getSource()->getOptionText($value);
 
-            if (empty($value)) {
+            if (is_array($value)) {
+                $value = implode('|', $value);
+            } elseif (empty($value)) {
                 $inputType = $attribute->getFrontend()->getInputType();
                 if ($inputType == 'select' || $inputType == 'multiselect') {
                     return null;


### PR DESCRIPTION
- Solves issue: Mulltiselect attribute values are not correct exported in product export
- Description: 

Repaired multiselect values in FACTFinder_Core_Model_Export_Type_Product::_getAttributeValue

Multiselect attribute values need to be imploded if an array is returned , otherwise string "Array" gets exported to FF.
Mage_CatalogSearch_Model_Resource_Fulltext::_getAttributeValue uses the same logic for processing array values.

- Tested with Magento editions/versions: 1.9.3.1 (flat catalog and flat category are disabled)

- Tested with PHP versions: 5.6.29