### PR TITLE
Issue 195 undefined index fix

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/Pager.php
+++ b/src/app/code/community/FACTFinder/Core/Block/Catalog/Product/Pager.php
@@ -70,7 +70,7 @@ class FACTFinder_Core_Block_Catalog_Product_Pager extends Mage_Page_Block_Html_P
             return parent::getPagerUrl($params);
         }
 
-        $pageNum = $params['p'];
+        $pageNum = (isset($params['p']) ? $params['p'] : 0);
 
         if (!isset($this->_pagingUrls[$pageNum])) {
             $this->_pagingUrls[$pageNum] = '';


### PR DESCRIPTION
- Solves issue: https://github.com/Flagbit/Magento-FACTFinder/issues/195
- Description: Fixes the above issue by adding a check to the array before accessing else set the variable to 0 
- Tested with Magento editions/versions: EE:1.14.2.2
- Tested with PHP versions: 5.4.45