### PR TITLE
- Solves issue: 199 the method _isAttributeSearchable returns true for searchable attributes

### DIFF
--- a/src/app/code/community/FACTFinder/Core/Model/Export/Type/Product/Attribute.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Export/Type/Product/Attribute.php
@@ -348,7 +348,7 @@ class FACTFinder_Core_Model_Export_Type_Product_Attribute extends Mage_Core_Mode
         }
 
         if (!$attribute->getIsUserDefined()
-            || !$attribute->getIsSearchable()
+            || $attribute->getIsSearchable()
             || in_array($attribute->getAttributeCode(), $this->getExportAttributes($storeId))
         ) {
             return true;


### PR DESCRIPTION
- Description: the existing implementation did not detect searchable attributes because of a parity error in front of $attribute->getIsSearchable()
- Tested with Magento editions/versions: 1.14.3.2 EE
- Tested with PHP versions: 5.6.30