### PR TITLE
Solves issue: 201 (module attribute definitions)

### DIFF
--- a/src/app/etc/modules/FACTFinder_Recommendation.xml
+++ b/src/app/etc/modules/FACTFinder_Recommendation.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <FACTFinder_Recommendation>
-            <active>1</active>
+            <active>true</active>
             <codePool>community</codePool>
             <depends>
                 <FACTFinder_Core/>

--- a/src/app/etc/modules/FACTFinder_Tagcloud.xml
+++ b/src/app/etc/modules/FACTFinder_Tagcloud.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <FACTFinder_Tagcloud>
-            <active>1</active>
+            <active>true</active>
             <codePool>community</codePool>
             <depends>
                 <FACTFinder_Core/>

--- a/src/app/etc/modules/FACTFinder_Tracking.xml
+++ b/src/app/etc/modules/FACTFinder_Tracking.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <FACTFinder_Tracking>
-            <active>1</active>
+            <active>true</active>
             <codePool>community</codePool>
             <depends>
                 <FACTFinder_Core/>


### PR DESCRIPTION
- Description: Magento uses 'true' as active flag and any other entries are interpreted as false
- Tested with Magento editions/versions: 1.14.3.2 EE
- Tested with PHP versions: 5.6.30