### PR TITLE
enhanced record data extraction #104

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,9 +9,9 @@
     <description>Integrates the FACT-Finder for improved product search functionality.</description>
     <license>The MIT License (MIT)</license>
     <license_uri>https://opensource.org/licenses/MIT</license_uri>
-    <version>4.1.13</version>
+    <version>4.1.14</version>
     <stability>stable</stability>
-    <notes>Completely refactored and now supporting FF v6.9-7.2</notes>
+    <notes>Completely refactored and now supporting FF v6.9-7.3</notes>
     <authors>
         <names>
             <name><![CDATA[Flagbit GmbH & Co. KG]]></name>

--- a/src/app/code/community/FACTFinder/Campaigns/Model/Resource/Pushedproducts/Collection.php
+++ b/src/app/code/community/FACTFinder/Campaigns/Model/Resource/Pushedproducts/Collection.php
@@ -103,8 +103,11 @@ class FACTFinder_Campaigns_Model_Resource_Pushedproducts_Collection
         foreach ($campaigns->getPushedProducts() as $record) {
             $productIds[$record->getId()] = new Varien_Object(
                 array(
-                    'similarity'        => $record->getSimilarity(),
-                    'position'          => $record->getPosition(),
+                    'similarity'  => $record->getSimilarity(),
+                    'position'    => $record->getPosition(),
+                    'campaign'    => $record->getField(FACTFinder_Core_Model_Handler_Search::CAMPAIGN_NAME_FIELD),
+                    'instore_ads' => $record->getField(FACTFinder_Core_Model_Handler_Search::INSTOREADS_PRODUCT_FIELD),
+                    'variant_id'  => $record->getField(FACTFinder_Core_Model_Handler_Search::VARIANT_ID_FIELD)
                 )
             );
         }

--- a/src/app/code/community/FACTFinder/Core/Model/Handler/Search.php
+++ b/src/app/code/community/FACTFinder/Core/Model/Handler/Search.php
@@ -32,6 +32,7 @@ class FACTFinder_Core_Model_Handler_Search extends FACTFinder_Core_Model_Handler
     const ORIGINAL_POSITION_FIELD    = '__ORIG_POSITION__';
     const CAMPAIGN_NAME_FIELD        = '__FFCampaign__';
     const INSTOREADS_PRODUCT_FIELD   = '__FFInstoreAds__';
+    const VARIANT_ID_FIELD           = 'id';
 
     protected $_searchResult;
     protected $_searchResultCount;
@@ -182,11 +183,12 @@ class FACTFinder_Core_Model_Handler_Search extends FACTFinder_Core_Model_Handler
 
                     $this->_searchResult[$record->getId()] = new Varien_Object(
                         array(
-                            'similarity' => $record->getSimilarity(),
-                            'position' => $record->getPosition(),
+                            'similarity'        => $record->getSimilarity(),
+                            'position'          => $record->getPosition(),
                             'original_position' => $record->getField(self::ORIGINAL_POSITION_FIELD),
-                            'campaign' => $record->getField(self::CAMPAIGN_NAME_FIELD),
-                            'instore_ads' => $record->getField(self::INSTOREADS_PRODUCT_FIELD)
+                            'campaign'          => $record->getField(self::CAMPAIGN_NAME_FIELD),
+                            'instore_ads'       => $record->getField(self::INSTOREADS_PRODUCT_FIELD),
+                            'variant_id'        => $record->getField(self::VARIANT_ID_FIELD)
                         )
                     );
                 }


### PR DESCRIPTION
- Solves issue: #104
- Description: `$product->getVariantId()` supported
- Tested with Magento editions/versions:  CE 1.9.3.2
- Tested with PHP versions: 5.6.30