### PR TITLE
ASN filter properties not accessible #205

### DIFF
--- a/src/app/code/community/FACTFinder/Asn/Block/Catalog/Layer/Factfinder.php
+++ b/src/app/code/community/FACTFinder/Asn/Block/Catalog/Layer/Factfinder.php
@@ -55,6 +55,10 @@ class FACTFinder_Asn_Block_Catalog_Layer_Factfinder extends Mage_Catalog_Block_L
             $this->setData((current($attribute->getItems())));
             $this->setUnit($attribute->getUnit());
             $this->setLinkCount($attribute->getLinkCount());
+        } else {
+            $this->setUnit($attribute->getUnit());
+            $this->setLinkCount($attribute->getLinkCount());
+            $this->setIsMultiselect($attribute->getIsMultiselect());
         }
 
         return $this;


### PR DESCRIPTION
- Solves issue:  #205
- Description:  see issue
- Tested with Magento editions/versions: CE 1.9.3.2
- Tested with PHP versions: 5.6.30