### PR TITLE
set proper content-type for JSONP response

### DIFF
--- a/src/app/code/community/FACTFinder/Suggest/Model/Processor.php
+++ b/src/app/code/community/FACTFinder/Suggest/Model/Processor.php
@@ -104,6 +104,9 @@ class FACTFinder_Suggest_Model_Processor
             $request = Mage::app()->loadCache($requestCacheId);
             if ($request) {
                 $content = $this->handleWithoutAppRequest();
+                if ($content) {
+                    Mage::app()->getResponse()->setHeader("Content-Type", "application/javascript;charset=utf-8", true);
+                }
             }
         }
 

--- a/src/app/code/community/FACTFinder/Suggest/controllers/ProxyController.php
+++ b/src/app/code/community/FACTFinder/Suggest/controllers/ProxyController.php
@@ -34,7 +34,7 @@ class FACTFinder_Suggest_ProxyController extends Mage_Core_Controller_Front_Acti
             return;
         }
 
-        $this->getResponse()->setHeader("Content-Type", "application/json;charset=utf-8", true);
+        $this->getResponse()->setHeader("Content-Type", "application/javascript;charset=utf-8", true);
         $this->getResponse()->setBody(
             Mage::getModel('factfinder_suggest/processor')->handleInAppRequest($this->getFullActionName())
         );


### PR DESCRIPTION
- Solves issue: Browser rejects JSONP response due to invalid content-type
- Description: change MIME/content-type for JSONP response of Suggest to `application/javascript`
- Tested with Magento editions/versions: 1.9.x
- Tested with PHP versions: 7.0

### Please note that the source and target branch must be "develop" (details: https://github.com/Flagbit/Magento-FACTFinder/wiki/Guide-for-Contributors).