### PR TITLE
Fix Warning: sizeof(): Parameter must be an array or an object that i…

### DIFF
--- a/src/lib/FACTFinder/Record.php
+++ b/src/lib/FACTFinder/Record.php
@@ -217,7 +217,7 @@ class FACTFinder_Record
         } else if (is_string($field)) {
             if (!isset($this->fieldNames[$field])) {
                 // create a new field
-                $this->fieldNames[$field] = sizeof($this->fieldValues);
+                $this->fieldNames[$field] = is_countable($this->fieldValues) ? sizeof($this->fieldValues) : 0;
                 $this->fieldValues[] = $value;
             } else {
                 $this->fieldValues[$this->fieldNames[$field]] = $value;


### PR DESCRIPTION
…mplements Countable

- Solves issue: Warning: sizeof(): Parameter must be an array or an object that implements Countable
- Description: 
- Tested with Magento editions/versions: 1.14.2.3
- Tested with PHP versions: 7.2.28-3+ubuntu16.04.1+deb.sury.org+1

### Please note that the source and target branch must be "develop" (details: https://github.com/Flagbit/Magento-FACTFinder/wiki/Guide-for-Contributors).